### PR TITLE
Fix potential injection for parameter dictionaries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "cpyint"]
-	path = cpyint
-	url = ../connector-python-internal.git
-	branch = master

--- a/lib/cpy_distutils.py
+++ b/lib/cpy_distutils.py
@@ -25,9 +25,14 @@
 """Implements the DistUtils command 'build_ext'
 """
 
-from distutils.command.build_ext import build_ext
-from distutils.command.install import install
-from distutils.command.install_lib import install_lib
+try:
+    from setuptools.command.build_ext import build_ext
+    from setuptools.command.install import install
+    from setuptools.command.install_lib import install_lib
+except ImportError:
+    from distutils.command.build_ext import build_ext
+    from distutils.command.install import install
+    from distutils.command.install_lib import install_lib
 from distutils.errors import DistutilsExecError
 from distutils.util import get_platform
 from distutils.dir_util import copy_tree

--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -44,6 +44,14 @@ RE_SQL_INSERT_STMT = re.compile(
     re.I | re.M | re.S)
 RE_SQL_INSERT_VALUES = re.compile(r'.*VALUES\s*(\(.*\)).*', re.I | re.M | re.S)
 RE_PY_PARAM = re.compile(b'(%s)')
+RE_PY_MAPPING_PARAM = re.compile(
+    br"""
+    %
+    \((?P<mapping_key>[^)]+)\)
+    (?P<conversion_type>[diouxXeEfFgGcrs%])
+    """,
+    re.X
+)
 RE_SQL_SPLIT_STMTS = re.compile(
     b''';(?=(?:[^"'`]*["'`][^"'`]*["'`])*[^"'`]*$)''')
 RE_SQL_FIND_PARAM = re.compile(
@@ -73,6 +81,29 @@ class _ParamSubstitutor(object):
     def remaining(self):
         """Returns number of parameters remaining to be substituted"""
         return len(self.params) - self.index
+
+
+def _bytestr_format_dict(bytestr, value_dict):
+    """
+    >>> _bytestr_format_dict(b'%(a)s', {b'a': b'foobar'})
+    b'foobar
+    >>> _bytestr_format_dict(b'%%(a)s', {b'a': b'foobar'})
+    b'%%(a)s'
+    >>> _bytestr_format_dict(b'%%%(a)s', {b'a': b'foobar'})
+    b'%%foobar'
+    >>> _bytestr_format_dict(b'%(x)s %(y)s',
+    ...                      {b'x': b'x=%(y)s', b'y': b'y=%(x)s'})
+    b'x=%(y)s y=%(x)s'
+    """
+    def replace(matchobj):
+        groups = matchobj.groupdict()
+        if groups['conversion_type'] == b'%':
+            return b'%'
+        if groups['conversion_type'] == b's':
+            return value_dict[groups['mapping_key']]
+        raise ValueError("Unsupported conversion_type: " +
+                         groups['conversion_type'])
+    return RE_PY_MAPPING_PARAM.sub(replace, bytestr)
 
 
 class CursorBase(MySQLCursorAbstract):
@@ -360,9 +391,9 @@ class MySQLCursor(CursorBase):
                 conv = escape(conv)
                 conv = quote(conv)
                 if PY2:
-                    res["%({0})s".format(key)] = conv
+                    res[key] = conv
                 else:
-                    res["%({0})s".format(key).encode()] = conv
+                    res[key.encode()] = conv
         except Exception as err:
             raise errors.ProgrammingError(
                 "Failed processing pyformat-parameters; %s" % err)
@@ -497,8 +528,8 @@ class MySQLCursor(CursorBase):
 
         if params is not None:
             if isinstance(params, dict):
-                for key, value in self._process_params_dict(params).items():
-                    stmt = stmt.replace(key, value)
+                stmt = _bytestr_format_dict(
+                    stmt, self._process_params_dict(params))
             elif isinstance(params, (list, tuple)):
                 psub = _ParamSubstitutor(self._process_params(params))
                 stmt = RE_PY_PARAM.sub(psub, stmt)
@@ -551,8 +582,8 @@ class MySQLCursor(CursorBase):
             for params in seq_params:
                 tmp = fmt
                 if isinstance(params, dict):
-                    for key, value in self._process_params_dict(params).items():
-                        tmp = tmp.replace(key, value)
+                    tmp = _bytestr_format_dict(
+                        tmp, self._process_params_dict(params))
                 else:
                     psub = _ParamSubstitutor(self._process_params(params))
                     tmp = RE_PY_PARAM.sub(psub, tmp)

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,17 @@ To install MySQL Connector/Python:
 
 """
 
-from distutils.core import setup
 from distutils.command.install import INSTALL_SCHEMES
 
 # Make sure that data files are actually installed in the package directory
 for install_scheme in INSTALL_SCHEMES.values():
     install_scheme['data'] = install_scheme['purelib']
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 
 import setupinfo
 try:

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -421,6 +421,8 @@ class MySQLCursorTests(tests.TestsCursor):
             'p': datetime.time(20, 3, 23),
             'q': st_now,
             'r': datetime.timedelta(hours=40, minutes=30, seconds=12),
+            's': 'foo %(t)s',
+            't': 'foo %(s)s',
         }
         exp = {
             b'%(a)s': b'NULL',
@@ -443,6 +445,8 @@ class MySQLCursorTests(tests.TestsCursor):
             time.strftime('%Y-%m-%d %H:%M:%S', st_now).encode('ascii')
             + b"'",
             b'%(r)s': b"'40:30:12'",
+            b's': b'foo %(t)s',
+            b't': b'foo %(s)s',
         }
 
         self.cnx = connection.MySQLConnection(**tests.get_mysql_config())


### PR DESCRIPTION
The old one-by-one replacement workflow was vulnerable to expanding of format-fields found in parameter values, e.g. with `params={'x': 'hello %(y)s world', 'y': 'i am injected'}` statement that involves `x=%(x)s` might expand to `x='hello 'i am injected' world'`.
